### PR TITLE
fix(#52): refactor to useDerivedStateFromProps to avoid deprecation warning

### DIFF
--- a/src/Field.js
+++ b/src/Field.js
@@ -4,26 +4,31 @@ import { FormControl, FormArray, FormGroup } from './model'
 import { isFunction, warning } from './utils'
 
 export default class Field extends React.Component {
-  componentDidMount() {
-    const { control } = this.props
-    // Add listener
-    this.addListener(control)
+  state = {
+    forceUpdate: () => this.forceUpdate()
   }
-  componentWillReceiveProps(nextProps) {
-    const { control } = nextProps
-    if (this.props.control !== control) {
-      this.removeListener(control)
-      this.addListener(control)
+
+  static getDerivedStateFromProps(nextProps, prevState) {
+    const { control } = nextProps;
+    if (control !== prevState.lastControl) {
+      Field.removeListener(control);
+      Field.addListener(control, prevState.forceUpdate);
+      return {
+        ...prevState,
+        lastControl: control
+      }
     }
+    return null
   }
-  addListener(control) {
+
+  static addListener(control, forceUpdate) {
     if (control) {
       control.stateChanges.subscribe(() => {
-        this.forceUpdate()
+        forceUpdate()
       })
     }
   }
-  removeListener(control) {
+  static removeListener(control) {
     if (control) {
       if (control.stateChanges.observers) {
         control.stateChanges.observers.forEach(observer => {
@@ -35,7 +40,7 @@ export default class Field extends React.Component {
   componentWillUnmount() {
     const { control } = this.props
     // Remove Listener
-    this.removeListener(control)
+    Field.removeListener(control)
   }
   shouldComponentUpdate(props) {
     if (!props.strict) {

--- a/src/FieldControl.js
+++ b/src/FieldControl.js
@@ -3,21 +3,27 @@ import PropTypes from 'prop-types'
 import { FormControl, FormArray, FormGroup } from './model'
 import configureControl from './configureControl'
 import Field from './Field'
-export default class FieldControl extends React.Component {
-  constructor(props, context) {
-    super(props, context)
-    this.control = configureControl(props, context, 'FormControl')
-  }
-  componentWillReceiveProps(nextProps) {
-    const { name } = nextProps
-    if (this.props.name !== name) {
-      this.control = configureControl(nextProps, this.context, 'FormControl')
+
+class FieldControlInternal extends React.Component {
+  state = {}
+
+  static getDerivedStateFromProps(nextProps, prevState) {
+    const { name } = nextProps;
+    if (!prevState || prevState.oldName !== name) {
+      return {
+        ...prevState,
+        control: configureControl(nextProps, {}, 'FormControl'),
+        oldName: name
+      }
     }
+    return null
   }
+
   render() {
     const { strict, children, render } = this.props
+    const { control } = this.state
     const FieldProps = {
-      control: this.control,
+      control,
       strict,
       render: render || children || null
     }
@@ -25,10 +31,10 @@ export default class FieldControl extends React.Component {
   }
 }
 
-FieldControl.defaultProps = {
+FieldControlInternal.defaultProps = {
   strict: true
 }
-FieldControl.propTypes = {
+FieldControlInternal.propTypes = {
   strict: PropTypes.bool,
   render: PropTypes.func,
   name: PropTypes.string,
@@ -58,9 +64,14 @@ FieldControl.propTypes = {
   ]),
   meta: PropTypes.object
 }
+
+const FieldControl = (props, context) => React.createElement(FieldControlInternal, {...props, parent: props.parent || context.parentControl})
+
 FieldControl.contextTypes = {
   parentControl: PropTypes.oneOfType([
     PropTypes.instanceOf(FormArray),
     PropTypes.instanceOf(FormGroup)
   ])
 }
+
+export default FieldControl


### PR DESCRIPTION
This should fix #52  - deprecation warnings and make the library compatible with React 17.x.
Being this my first upgrade to useDerivedStateFromProps, please check if what I've done makes sense (but it seems to be working just fine on my project).