### PR TITLE
fix(#52): refactor to componentDidMount to avoid deprecation warning

### DIFF
--- a/src/Field.js
+++ b/src/Field.js
@@ -9,9 +9,9 @@ export default class Field extends React.Component {
     // Add listener
     this.addListener(control)
   }
-  componentWillReceiveProps(nextProps) {
-    const { control } = nextProps
-    if (this.props.control !== control) {
+  componentDidUpdate(prevProps) {
+    const { control } = this.props
+    if (control !== prevProps.control) {
       this.removeListener(control)
       this.addListener(control)
     }

--- a/src/FieldControl.js
+++ b/src/FieldControl.js
@@ -8,10 +8,9 @@ export default class FieldControl extends React.Component {
     super(props, context)
     this.control = configureControl(props, context, 'FormControl')
   }
-  componentWillReceiveProps(nextProps) {
-    const { name } = nextProps
-    if (this.props.name !== name) {
-      this.control = configureControl(nextProps, this.context, 'FormControl')
+  componentDidUpdate(prevProps) {
+    if (this.props.name !== prevProps.name) {
+      this.control = configureControl(this.props, this.context, 'FormControl')
     }
   }
   render() {


### PR DESCRIPTION
This should fix #52 - deprecation warnings and make the library compatible with React 17.x.
This replaces PR #53 and addresses comments.