### PR TITLE
Change Observable#unsubscribe type signature

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -18,7 +18,7 @@ export type Handler = {
 export interface Observable<T> {
   observers: Array<T>
   subscribe: (fn: Function) => void
-  unsubscribe: (fn: Function) => void
+  unsubscribe: (fn?: Function) => void
 }
 type Meta = {
   value: any


### PR DESCRIPTION
The current type declaration file says that `Observable#unsubscribe` method accepts `fn` parameter with `Function` type. In fact, this parameter [can be omitted](https://github.com/bietkul/react-reactive-form/blob/master/src/observable.js#L8). It would be more correct to make this type optional.